### PR TITLE
Wallet Drop-Down: Hide the whole DropDown-Item instead of only the Button

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -40,32 +40,20 @@
             />
           </b-navbar-brand>
           <b-dropdown variant="primary" class="mx-1" right text="My Wallet">
-            <b-dropdown-item>
-              <b-button
-                v-show="!$refs.walletComponent.wallet.isWalletUnlocked"
-                variant="success"
-                @click="$refs.walletComponent.newWallet()"
-              >
+            <b-dropdown-item v-show="!$refs.walletComponent.wallet.isWalletUnlocked">
+              <b-button variant="success" @click="$refs.walletComponent.newWallet()">
                 Create New Wallet
               </b-button>
             </b-dropdown-item>
 
-            <b-dropdown-item>
-              <b-button
-                v-show="!$refs.walletComponent.wallet.isWalletUnlocked"
-                variant="primary"
-                @click="$refs.walletComponent.showRecoverWalletModal()"
-              >
+            <b-dropdown-item v-show="!$refs.walletComponent.wallet.isWalletUnlocked">
+              <b-button variant="primary" @click="$refs.walletComponent.showRecoverWalletModal()">
                 Recover Wallet
               </b-button>
             </b-dropdown-item>
 
-            <b-dropdown-item>
-              <b-button
-                v-show="!$refs.walletComponent.wallet.isWalletUnlocked"
-                variant="primary"
-                @click="$refs.walletComponent.showUnlockWalletModal()"
-              >
+            <b-dropdown-item v-show="!$refs.walletComponent.wallet.isWalletUnlocked">
+              <b-button variant="primary" @click="$refs.walletComponent.showUnlockWalletModal()">
                 Unlock Wallet
               </b-button>
             </b-dropdown-item>
@@ -73,26 +61,16 @@
             <!--
             Todo - enable when Ledger app released
             {{
-            <b-dropdown-item>
-              <b-button
-                v-show="!$refs.walletComponent.wallet.isWalletUnlocked"
-                variant="primary"
-                @click="
-                  $refs.walletComponent.showConnectLedgerModal(), $refs.walletComponent.selectLedgerWallet()
-                "
-              >
+            <b-dropdown-item v-show="!$refs.walletComponent.wallet.isWalletUnlocked">
+              <b-button variant="primary" @click="$refs.walletComponent.showConnectLedgerModal(), $refs.walletComponent.selectLedgerWallet()">
                 Connect Ledger Device
               </b-button>
             </b-dropdown-item>
             }}
             -->
 
-            <b-dropdown-item>
-              <b-button
-                v-show="$refs.walletComponent.wallet.isWalletUnlocked"
-                variant="primary"
-                @click="$refs.walletComponent.closeWallet()"
-              >
+            <b-dropdown-item v-show="$refs.walletComponent.wallet.isWalletUnlocked">
+              <b-button variant="primary" @click="$refs.walletComponent.closeWallet()">
                 Close Wallet
               </b-button>
             </b-dropdown-item>

--- a/src/store/modules/validators.js
+++ b/src/store/modules/validators.js
@@ -55,7 +55,7 @@ const actions = {
     const keys = Object.keys(context.state.validators)
     for (let i = 0; i < keys.length; i += 1) {
       if (Object.prototype.hasOwnProperty.call(context.state.validators, keys[i])) {
-        if (context.state.validators[keys[i]].status !== 0) {
+        if (context.state.validators[keys[i]].status === 2) {
           const valOption = {
             value: keys[i],
             text: context.state.validators[keys[i]].description.moniker,


### PR DESCRIPTION
In the wallet Drop-Down Menu in the navigation bar there are Drop-Down-Item with buttons (create wallet and so on).<br>Depending on the client state (wallet opened/closed) some of the buttons are "invisible", but the Drop-Down items are visible too. That results in "blue bars" if the mouse cursor hovers the empty Drop-Down-Items.
With this pull request, not only the buttons are invisible, but also the whole Drop-Down-Items. Now there are no "blue bars" in the wallet Drop-Down Menu.