### PR TITLE
Fix governance proposals being cached in local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-wallet",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "private": true,
   "description": "Unification Mainchain Web Wallet",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/runtime": "^7.12.18",
     "@chenfengyuan/vue-countdown": "^1.1.5",
     "@ledgerhq/hw-transport": "^5.43.0",
-    "@unification-com/und-js-v2": "^0.1.1",
+    "@unification-com/und-js-v2": "^0.1.6",
     "bech32": "^2.0.0",
     "big.js": "^5.2.2",
     "bootstrap": "^4.6.0",

--- a/src/components/Governance/Governance.vue
+++ b/src/components/Governance/Governance.vue
@@ -118,6 +118,14 @@
             <tbody>
               <tr>
                 <td class="gov-proposal-th">
+                  Your Vote
+                </td>
+                <td>
+                  {{ getVoteOptionText(row.item.myVote) }}
+                </td>
+              </tr>
+              <tr>
+                <td class="gov-proposal-th">
                   Vote
                 </td>
                 <td>
@@ -172,7 +180,6 @@
                         row.item.myVote !== 'NOT_VOTED' && row.item.status === 'PROPOSAL_STATUS_VOTING_PERIOD'
                       "
                     >
-                      You voted {{ getVoteOptionText(row.item.myVote) }}
                     </span>
                   </div>
                 </td>
@@ -264,8 +271,10 @@ export default {
           return "Abstain"
         case "VOTE_OPTION_NO_WITH_VETO":
           return "No with Veto"
+        case "NOT_VOTED":
+          return "Not Voted"
         default:
-          return "Something went wrong"
+          return voteOption
       }
     },
     async getProposals() {

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -346,6 +346,7 @@ export default {
       txs: state => state.txs,
       validators: state => state.validators,
       delegations: state => state.delegations,
+      governance: state => state.governance,
     }),
     hdPathOptions() {
       const hdPathOptions = []
@@ -418,6 +419,7 @@ export default {
       await this.$store.dispatch("txs/clearTxs")
       await this.$store.dispatch("validators/clearValidators")
       await this.$store.dispatch("delegations/clearAll")
+      await this.$store.dispatch("governance/clearProposals")
       this.isMnemonicSaved = false
       this.walletPass = null
       this.privateKey = null

--- a/src/store/modules/governance.js
+++ b/src/store/modules/governance.js
@@ -17,6 +17,10 @@ const getters = {
 
 // actions
 const actions = {
+  clearProposals(context) {
+    context.commit("clearProposals")
+  },
+
   addEditProposal(context, proposal) {
     if (Object.prototype.hasOwnProperty.call(context.state.proposals, proposal.proposal_id)) {
       context.commit("editProposal", proposal)
@@ -60,6 +64,10 @@ const mutations = {
   },
   setMyVote(state, payload) {
     state.proposals[payload.proposal_id].myVote = payload.myVote
+  },
+
+  clearProposals(state) {
+    state.proposals = {}
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,6 +949,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.18.3":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
+  integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
+  dependencies:
+    regenerator-runtime "^0.13.10"
+
 "@babel/template@^7.0.0", "@babel/template@^7.16.7", "@babel/template@^7.4.0":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -1701,11 +1708,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@unification-com/und-js-v2@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@unification-com/und-js-v2/-/und-js-v2-0.1.1.tgz#62393b14123817d86e2b3610bfffe0e527cc811c"
-  integrity sha512-xw04FWbGUEua+a+IYTn2PP1yxR2KsQNw2fe/Y3Wg1ifXDJvQ8f7Xt7RibIZYXYQBDpebgLT+g9WZidb2CTVuqg==
+"@unification-com/und-js-v2@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@unification-com/und-js-v2/-/und-js-v2-0.1.6.tgz#3ef223bad58af608187b3ed3bea53c7164e191c9"
+  integrity sha512-xXQqRHzXZJkpDuNoldGR2uXkhHV2GxxOThplDCXyIswyJWPY/vkmgo28y3vbq137XJQQCB5Lrxys/U/60GjYzA==
   dependencies:
+    "@babel/runtime" "^7.18.3"
     ansi-regex "^5.0.1"
     bech32 "^1.1.3"
     big.js "^6.1.1"
@@ -9201,6 +9209,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.10:
+  version "0.13.10"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
+  integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"


### PR DESCRIPTION
Some minor fixes, including:

- Clear proposals from the `governance` local storage when a wallet is closed, or network changes
- Add text output for the "NOT_VOTED" vote status
- Move "You Voted" info for a proposal to its own row
- Bump `und-js-v2` to v0.1.6